### PR TITLE
adding maven 17 folder for lts upgrade

### DIFF
--- a/build/maven-java17/Dockerfile
+++ b/build/maven-java17/Dockerfile
@@ -1,0 +1,31 @@
+#FROM egovio/alpine-maven-builder-jdk-8:1-master-NA-6036091e AS build
+FROM egovio/amazoncorretto:17-alpine3.19 AS build
+ARG WORK_DIR
+WORKDIR /app
+
+# Install Maven
+RUN apk add --no-cache maven
+
+# copy the project files
+COPY ${WORK_DIR}/pom.xml ./pom.xml
+COPY build/maven/start.sh ./start.sh
+
+# not useful for stateless builds
+# RUN mvn -B dependency:go-offline
+
+COPY ${WORK_DIR}/src ./src
+RUN mvn -B -f /app/pom.xml package
+
+
+# Create runtime image
+#FROM egovio/8-openjdk-alpine
+FROM egovio/amazoncorretto:17-alpine3.19
+
+
+WORKDIR /opt/egov
+
+COPY --from=build /app/target/*.jar /app/start.sh /opt/egov/
+
+RUN chmod +x /opt/egov/start.sh
+
+CMD ["/opt/egov/start.sh"]

--- a/build/maven-java17/start.sh
+++ b/build/maven-java17/start.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [[ -z "${JAVA_OPTS}" ]];then
+    export JAVA_OPTS="-Xmx64m -Xms64m"
+fi
+
+if [ x"${JAVA_ENABLE_DEBUG}" != x ] && [ "${JAVA_ENABLE_DEBUG}" != "false" ]; then
+    java_debug_args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUG_PORT:-5005}"
+fi
+
+exec java ${java_debug_args} ${JAVA_OPTS} ${JAVA_ARGS}  -jar /opt/egov/*.jar


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Dockerfile for building and running Java applications using Maven and Amazon Corretto 17.
	- Added a shell script (`start.sh`) to streamline the startup process of the Java application with configurable memory and debugging options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->